### PR TITLE
Allow profiling multiple renderer processes.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,17 +7,17 @@ declare module 'v8-inspect-profiler' {
     }
 
     export interface Target {
-		description: string,
-    	devtoolsFrontendUrl: string,
-		id: string,
-		title: string,
-		type: string,
-		url: string,
-		webSocketDebuggerUrl: string
-	}
+        description: string,
+        devtoolsFrontendUrl: string,
+        id: string,
+        title: string,
+        type: string,
+        url: string,
+        webSocketDebuggerUrl: string
+    }
 
-	export function listTabs(options: { port: number, tries?: number, retyWait?: number }): PromiseLike<Target[]>;
-	export function startProfiling(options: { port: number, tries?: number, retyWait?: number, chooseTab?: (targets: Target[]) => any }): PromiseLike<ProfilingSession>;
+    export function listTabs(options: { port: number, tries?: number, retyWait?: number }): PromiseLike<Target[]>;
+    export function startProfiling(options: { port: number, tries?: number, retyWait?: number, chooseTab?: (targets: Target[]) => Target }): PromiseLike<ProfilingSession>;
     export function writeProfile(profile: Profile, name?: string): PromiseLike<void>;
     export function rewriteAbsolutePaths(profile, replaceWith?);
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,18 @@ declare module 'v8-inspect-profiler' {
         stop(afterDelay?: number): PromiseLike<Profile>;
     }
 
-    export function startProfiling(options: { port: number, tries?: number, retyWait?: number }): PromiseLike<ProfilingSession>;
+    export interface Target {
+		description: string,
+    	devtoolsFrontendUrl: string,
+		id: string,
+		title: string,
+		type: string,
+		url: string,
+		webSocketDebuggerUrl: string
+	}
+
+	export function listTabs(options: { port: number, tries?: number, retyWait?: number }): PromiseLike<Target[]>;
+	export function startProfiling(options: { port: number, tries?: number, retyWait?: number, chooseTab?: (targets: Target[]) => any }): PromiseLike<ProfilingSession>;
     export function writeProfile(profile: Profile, name?: string): PromiseLike<void>;
     export function rewriteAbsolutePaths(profile, replaceWith?);
 }

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ async function wait(n) {
     return new Promise(resolve => setTimeout(resolve, n));
 }
 
-async function connectWithRetry(port, tries = 10, retryWait = 50, errors = []) {
-    function chooseTab(targets) {
+async function connectWithRetry(port, tries = 10, retryWait = 50, errors = [], chooseTab) {
+    chooseTab = chooseTab || function (targets) {
         const target = targets.find(target => {
             if (target.webSocketDebuggerUrl) {
                 if (target.type === 'page') {
@@ -33,7 +33,7 @@ async function connectWithRetry(port, tries = 10, retryWait = 50, errors = []) {
             };
         }
         return target;
-    }
+    };
 
     try {
         return await cdp({
@@ -46,13 +46,13 @@ async function connectWithRetry(port, tries = 10, retryWait = 50, errors = []) {
             throw errors;
         }
         await wait(retryWait);
-        return connectWithRetry(port, tries, retryWait, errors);
+        return connectWithRetry(port, tries, retryWait, errors, chooseTab);
     }
 }
 
 async function startProfiling(options) {
 
-    const client = await connectWithRetry(options.port, options.tries, options.retryWait);
+    const client = await connectWithRetry(options.port, options.tries, options.retryWait, [], options.chooseTab);
     const { Runtime, Profiler } = client;
 
     await Runtime.runIfWaitingForDebugger();

--- a/index.js
+++ b/index.js
@@ -100,5 +100,6 @@ async function writeProfile(profileData, filename = `profile-${Date.now()}.cpupr
 module.exports = {
     startProfiling,
     writeProfile,
-    rewriteAbsolutePaths
+    rewriteAbsolutePaths,
+    listTabs: cdp.listTabs
 }

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ async function writeProfile(profileData, filename = `profile-${Date.now()}.cpupr
 module.exports = {
     startProfiling,
     writeProfile,
-	rewriteAbsolutePaths,
-	// @ts-ignore
-	listTabs: cdp.listTabs
+    rewriteAbsolutePaths,
+    // @ts-ignore
+    listTabs: cdp.listTabs
 }

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ async function writeProfile(profileData, filename = `profile-${Date.now()}.cpupr
 module.exports = {
     startProfiling,
     writeProfile,
-    rewriteAbsolutePaths,
-    listTabs: cdp.listTabs
+	rewriteAbsolutePaths,
+	// @ts-ignore
+	listTabs: cdp.listTabs
 }


### PR DESCRIPTION
This PR includes

* Expose cdp.listTab and library users can create interactive shell with all available renderer processes, similar to what `localost:{debugPort}` does for renderer processes.
* Add a new option `chooseTab` for `startProfiling`